### PR TITLE
Replace wget with curl for Steam Deck support

### DIFF
--- a/.github/workflows/AppRun
+++ b/.github/workflows/AppRun
@@ -5,7 +5,7 @@ export GDK_PIXBUF_MODULE_FILE=$(pkg-config --variable=gdk_pixbuf_cache_file gdk-
 	
 mkdir -p $HOME/.local/share/icons/hicolor/scalable/apps && cp $APPDIR/yuzu.svg $HOME/.local/share/icons/hicolor/scalable/apps
 
-GITVER=`( wget -qO- https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest || curl -sL https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest ) | grep "EA-" | grep -o 'EA-[[:digit:]]*'`
+GITVER=`( wget -qO- https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest 2>/dev/null || curl -sL https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest ) | grep "EA-" | grep -o 'EA-[[:digit:]]*'`
 APPVER=`cat $APPDIR/version.txt`
 
 if [[ -z "$GITVER" ]]; then

--- a/.github/workflows/AppRun
+++ b/.github/workflows/AppRun
@@ -5,7 +5,7 @@ export GDK_PIXBUF_MODULE_FILE=$(pkg-config --variable=gdk_pixbuf_cache_file gdk-
 	
 mkdir -p $HOME/.local/share/icons/hicolor/scalable/apps && cp $APPDIR/yuzu.svg $HOME/.local/share/icons/hicolor/scalable/apps
 
-GITVER=`curl -sL https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest | grep "EA-" | grep -o 'EA-[[:digit:]]*'`
+GITVER=`( wget -qO- https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest || curl -sL https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest ) | grep "EA-" | grep -o 'EA-[[:digit:]]*'`
 APPVER=`cat $APPDIR/version.txt`
 
 if [[ -z "$GITVER" ]]; then

--- a/.github/workflows/AppRun
+++ b/.github/workflows/AppRun
@@ -5,7 +5,7 @@ export GDK_PIXBUF_MODULE_FILE=$(pkg-config --variable=gdk_pixbuf_cache_file gdk-
 	
 mkdir -p $HOME/.local/share/icons/hicolor/scalable/apps && cp $APPDIR/yuzu.svg $HOME/.local/share/icons/hicolor/scalable/apps
 
-GITURL=`https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest`
+GITURL='https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest'
 GITVER=`( wget -qO- $GITURL 2>/dev/null || curl -sL $GITURL ) | grep "EA-" | grep -o 'EA-[[:digit:]]*'`
 APPVER=`cat $APPDIR/version.txt`
 

--- a/.github/workflows/AppRun
+++ b/.github/workflows/AppRun
@@ -5,7 +5,8 @@ export GDK_PIXBUF_MODULE_FILE=$(pkg-config --variable=gdk_pixbuf_cache_file gdk-
 	
 mkdir -p $HOME/.local/share/icons/hicolor/scalable/apps && cp $APPDIR/yuzu.svg $HOME/.local/share/icons/hicolor/scalable/apps
 
-GITVER=`( wget -qO- https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest 2>/dev/null || curl -sL https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest ) | grep "EA-" | grep -o 'EA-[[:digit:]]*'`
+GITURL=`https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest`
+GITVER=`( wget -qO- $GITURL 2>/dev/null || curl -sL $GITURL ) | grep "EA-" | grep -o 'EA-[[:digit:]]*'`
 APPVER=`cat $APPDIR/version.txt`
 
 if [[ -z "$GITVER" ]]; then

--- a/.github/workflows/AppRun
+++ b/.github/workflows/AppRun
@@ -5,7 +5,7 @@ export GDK_PIXBUF_MODULE_FILE=$(pkg-config --variable=gdk_pixbuf_cache_file gdk-
 	
 mkdir -p $HOME/.local/share/icons/hicolor/scalable/apps && cp $APPDIR/yuzu.svg $HOME/.local/share/icons/hicolor/scalable/apps
 
-GITVER=`wget -qO- https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest | grep "EA-" | grep -o 'EA-[[:digit:]]*'`
+GITVER=`curl -sL https://api.github.com/repos/pineappleEA/pineapple-src/releases/latest | grep "EA-" | grep -o 'EA-[[:digit:]]*'`
 APPVER=`cat $APPDIR/version.txt`
 
 if [[ -z "$GITVER" ]]; then


### PR DESCRIPTION
wget is not included in SteamOS and not easy to install because the file system is read-only by default and any changes will get wiped by the next system update. This is the only instance where wget is used, curl is used extensively in appimage.sh.