### PR TITLE
Correct variable expansion

### DIFF
--- a/.github/workflows/update.sh
+++ b/.github/workflows/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-directory=${APPIMAGE%$ARGV0}
+directory=${APPIMAGE%${ARGV0/*\//}}
 
 if [ -w $directory ] ; then
 	zenity --question --timeout=10 --title="yuzu updater" --text="New update available. Update now?" --icon-name=yuzu --window-icon=yuzu.svg --height=80 --width=400


### PR DESCRIPTION
fixes https://github.com/pineappleEA/pineapple-src/issues/70

This ensures that Pineapple will update even if the file name has been changed.
It launches the known filename `yuzu-x86_64.AppImage`

Fixes an error where `./` was appended to the filename causing it to create duplicate names and failing to launch.